### PR TITLE
Update maven download urls to use https

### DIFF
--- a/download.html
+++ b/download.html
@@ -135,13 +135,13 @@
     Downloads for the latest version are available as:
     <ul>
     <li>Commandline Application as Tar or Zip
-        (<a href="http://repo1.maven.org/maven2/org/mapfish/print/print-cli/" target="_blank">releases</a> or <a href="https://oss.sonatype.org/content/repositories/snapshots/org/mapfish/print/print-cli/" target="_blank">snapshots</a>)
+        (<a href="https://repo1.maven.org/maven2/org/mapfish/print/print-cli/" target="_blank">releases</a> or <a href="https://oss.sonatype.org/content/repositories/snapshots/org/mapfish/print/print-cli/" target="_blank">snapshots</a>)
     </li>
     <li>Web Application (WAR)
-        (<a href="http://repo1.maven.org/maven2/org/mapfish/print/print-servlet/" target="_blank">releases</a> or <a href="https://oss.sonatype.org/content/repositories/snapshots/org/mapfish/print/print-servlet/" target="_blank">snapshots</a>)
+        (<a href="https://repo1.maven.org/maven2/org/mapfish/print/print-servlet/" target="_blank">releases</a> or <a href="https://oss.sonatype.org/content/repositories/snapshots/org/mapfish/print/print-servlet/" target="_blank">snapshots</a>)
     </li>
     <li>Java Library (JAR)
-        (<a href="http://repo1.maven.org/maven2/org/mapfish/print/print-lib/" target="_blank">releases</a> or <a href="https://oss.sonatype.org/content/repositories/snapshots/org/mapfish/print/print-lib/" target="_blank">snapshots</a>)
+        (<a href="https://repo1.maven.org/maven2/org/mapfish/print/print-lib/" target="_blank">releases</a> or <a href="https://oss.sonatype.org/content/repositories/snapshots/org/mapfish/print/print-lib/" target="_blank">snapshots</a>)
     </li>
     </ul>
 </p>


### PR DESCRIPTION
Get following error when when trying to download releases from docs
https://mapfish.github.io/mapfish-print-doc/download.html#downloads

> 501 HTTPS Required. 
> Use https://repo1.maven.org/maven2/
> More information at https://links.sonatype.com/central/501-https-required

Caused by:
Effective 2020-01-15, the central maven repo no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS

http://maven.apache.org/docs/3.2.3/release-notes.html